### PR TITLE
Use bigger than or equal when comparing with payload

### DIFF
--- a/lib/async-timed-cargo.js
+++ b/lib/async-timed-cargo.js
@@ -52,7 +52,7 @@
                 data: task,
                 callback: typeof callback === 'function' ? callback : null
             });
-            if (tasks.length === payload) {
+            if (tasks.length >= payload) {
               cargo.process(); // TODO: check for stack overflow https://github.com/caolan/async/issues/696
             }
         });


### PR DESCRIPTION
Using bigger than or equal when comparing the tasks queue size with the payload, this way we guarantee that the payload will be respected even if the insertions are too fast
